### PR TITLE
Replace collective.xkey with collective.purgebyid

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ _Add-ons that help admins deploying and maintaining Plone_
 * [collective.catalogcleanup](https://github.com/collective/collective.catalogcleanup) - Removes data from the catalog that no longer belong to an actual object.
 * [collective.fingerpointing](https://github.com/collective/collective.fingerpointing) - Keeps track of different events and write them down to an audit log.
 * [collective.ifttt](https://github.com/collective/collective.ifttt) - Enables any Plone site to play in the IFTTT ecosystem. For example when a news item is published, then tweet about it or post it on Facebook.
+* [collective.purgebyid](https://github.com/collective/collective.purgebyid) - Use tag-based cache invalidation in Plone (e.g. with Varnish's xkey module).
 * [collective.recipe.backup](https://github.com/collective/collective.recipe.backup) - Powerful and flexible backup/restore solution for Plone.
 * [collective.revisionmanager](https://github.com/collective/collective.revisionmanager) - Manage Products.CMFEditions histories that can bloat your database.
 * [collective.sentry](https://github.com/collective/collective.sentry) - Sentry integration to aggregate errors and help finding their causes.
-* [collective.xkey](https://github.com/collective/collective.xkey) - Use Varnish's xkey module for tag-based cache invalidation in Plone.
 * [dm.historical](https://pypi.org/project/dm.historical) - Access any historical state of your database. Can be useful to find out what happened to objects in the past and to restore accidentally deleted or modified objects.
 * [haufe.requestmonitoring](https://github.com/collective/haufe.requestmonitoring) - Detailed request logging functionality on top of the publication events. Useful to find out what takes longer than it should.
 


### PR DESCRIPTION
c.purgebyid was already the inspiration of c.xkey and now with all improvements from c.xkey (see [PR](https://github.com/collective/collective.purgebyid/pull/4)) being ported, there is no reason to still promote my add-on. As it supports the whole feature set, I therefor suggest to replace it.