### PR TITLE
collective.splitsitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ _Add-ons for search engine optimization._
 
 * [bda.plone.gtm](https://github.com/bluedynamics/bda.plone.gtm) - Google Tag Manager Integration.
 * [collective.behavior.seo](https://github.com/collective/collective.behavior.seo) - Adds extra fields used for SEO optimisation.
-
-
+* [collective.splitsitemap](https://github.com/collective/collective.splitsitemap) - Provides a cached split sitemap on big public sites.
 
 ## Authentication
 


### PR DESCRIPTION
If you have a big public website you might get in to trouble because:

1. generating the sitemap might take time
2. if you reach the [50k items limit](https://www.sitemaps.org/faq.html#faq_sitemap_size) you will get indexing issues

This add-on provides a solution for both the issues. It is well written and has a nice control panel.