### PR TITLE
Add collective.regenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ _Add-ons that help admins deploying and maintaining Plone_
 * [collective.ifttt](https://github.com/collective/collective.ifttt) - Enables any Plone site to play in the IFTTT ecosystem. For example when a news item is published, then tweet about it or post it on Facebook.
 * [collective.purgebyid](https://github.com/collective/collective.purgebyid) - Use tag-based cache invalidation in Plone (e.g. with Varnish's xkey module).
 * [collective.recipe.backup](https://github.com/collective/collective.recipe.backup) - Powerful and flexible backup/restore solution for Plone.
-* [collective.regenv](https://github.com/collective/collective.regenv) - Override registry settings using environment variables
+* [collective.regenv](https://github.com/collective/collective.regenv) - Override registry settings using environment variables.
 * [collective.revisionmanager](https://github.com/collective/collective.revisionmanager) - Manage Products.CMFEditions histories that can bloat your database.
 * [collective.sentry](https://github.com/collective/collective.sentry) - Sentry integration to aggregate errors and help finding their causes.
 * [dm.historical](https://pypi.org/project/dm.historical) - Access any historical state of your database. Can be useful to find out what happened to objects in the past and to restore accidentally deleted or modified objects.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ _Add-ons that help admins deploying and maintaining Plone_
 * [collective.ifttt](https://github.com/collective/collective.ifttt) - Enables any Plone site to play in the IFTTT ecosystem. For example when a news item is published, then tweet about it or post it on Facebook.
 * [collective.purgebyid](https://github.com/collective/collective.purgebyid) - Use tag-based cache invalidation in Plone (e.g. with Varnish's xkey module).
 * [collective.recipe.backup](https://github.com/collective/collective.recipe.backup) - Powerful and flexible backup/restore solution for Plone.
+* [collective.regenv](https://github.com/collective/collective.regenv) - Override registry settings using environment variables
 * [collective.revisionmanager](https://github.com/collective/collective.revisionmanager) - Manage Products.CMFEditions histories that can bloat your database.
 * [collective.sentry](https://github.com/collective/collective.sentry) - Sentry integration to aggregate errors and help finding their causes.
 * [dm.historical](https://pypi.org/project/dm.historical) - Access any historical state of your database. Can be useful to find out what happened to objects in the past and to restore accidentally deleted or modified objects.


### PR DESCRIPTION
collective.regenv makes it possible to override portal_registry settings and PAS plugin settings using environment variables.

This avoids the need to create multiple GenericSetup profiles to account for differences between environments (like staging vs production)